### PR TITLE
chore: update CentOS Stream AMIs to v9

### DIFF
--- a/terraform/otel-ec2/vars.tf
+++ b/terraform/otel-ec2/vars.tf
@@ -172,7 +172,7 @@ variable "ec2_otels" {
         }
       }
       "amd64:centos-stream" = {
-        ami             = "ami-013f9ee48907190f5"
+        ami             = "ami-0be6cd7c3bdcdbf80"
         subnet          = "subnet-09b64de757828cdd4"
         security_groups = ["sg-044ef7bc34691164a"]
         key_name        = "caos-dev-arm"
@@ -185,7 +185,7 @@ variable "ec2_otels" {
         }
       }
       "arm64:centos-stream" = {
-        ami             = "ami-0dce27ea07b1afb8f"
+        ami             = "ami-08116befa629fbe3b"
         subnet          = "subnet-09b64de757828cdd4"
         security_groups = ["sg-044ef7bc34691164a"]
         key_name        = "caos-dev-arm"


### PR DESCRIPTION
Using the ones maintained by CentOS itself: https://www.centos.org/download/aws-images/