### PR TITLE
Revert "Moving infra-agent canaries to sandbox account (#36)"

### DIFF
--- a/terraform/otel-ec2/vars.tf
+++ b/terraform/otel-ec2/vars.tf
@@ -119,32 +119,6 @@ variable "ec2_otels" {
           "otel_role" = "agent"
         }
       }
-      "amd64:centos-stream" = {
-        ami             = "ami-01529018e3919dace"
-        subnet          = "subnet-09b64de757828cdd4"
-        security_groups = ["sg-044ef7bc34691164a"]
-        key_name        = "caos-dev-arm"
-        instance_type   = "t3a.small"
-        username        = "ec2-user"
-        python          = "/usr/bin/python3"
-        platform        = "linux"
-        tags            = {
-          "otel_role" = "agent"
-        }
-      }
-      "arm64:centos-stream" = {
-        ami             = "ami-0e98f9d5c9841c9ad"
-        subnet          = "subnet-09b64de757828cdd4"
-        security_groups = ["sg-044ef7bc34691164a"]
-        key_name        = "caos-dev-arm"
-        instance_type   = "t4g.small"
-        username        = "ec2-user"
-        python          = "/usr/bin/python3"
-        platform        = "linux"
-        tags            = {
-          "otel_role" = "agent"
-        }
-      }
       "amd64:sles-12.5" = {
         ami             = "ami-0314425a95f19ff16"
         subnet          = "subnet-09b64de757828cdd4"
@@ -190,19 +164,6 @@ variable "ec2_otels" {
         security_groups = ["sg-044ef7bc34691164a"]
         key_name        = "caos-dev-arm"
         instance_type   = "t3a.small"
-        username        = "ec2-user"
-        python          = "/usr/bin/python3"
-        platform        = "linux"
-        tags            = {
-          "otel_role" = "agent"
-        }
-      }
-      "arm64:sles-15.4" = {
-        ami             = "ami-052fd3067d337faf6"
-        subnet          = "subnet-09b64de757828cdd4"
-        security_groups = ["sg-044ef7bc34691164a"]
-        key_name        = "caos-dev-arm"
-        instance_type   = "t4g.small"
         username        = "ec2-user"
         python          = "/usr/bin/python3"
         platform        = "linux"

--- a/terraform/otel-ec2/vars.tf
+++ b/terraform/otel-ec2/vars.tf
@@ -69,8 +69,8 @@ variable "ec2_otels" {
   default = {
      "amd64:ubuntu24.04" = {
         ami             = "ami-09040d770ffe2224f"
-        subnet          = "subnet-0c2046d7a0595aa2c"
-        security_groups = ["sg-075f379cc5612e984"]
+        subnet          = "subnet-09b64de757828cdd4"
+        security_groups = ["sg-044ef7bc34691164a"]
         key_name        = "caos-dev-arm"
         instance_type   = "t3a.small"
         username        = "ubuntu"
@@ -82,8 +82,8 @@ variable "ec2_otels" {
       }
       "arm64:ubuntu24.04" = {
         ami             = "ami-0acb327475c6fd498"
-        subnet          = "subnet-0c2046d7a0595aa2c"
-        security_groups = ["sg-075f379cc5612e984"]
+        subnet          = "subnet-09b64de757828cdd4"
+        security_groups = ["sg-044ef7bc34691164a"]
         key_name        = "caos-dev-arm"
         instance_type   = "t4g.small"
         username        = "ubuntu"
@@ -95,8 +95,8 @@ variable "ec2_otels" {
       }
      "amd64:ubuntu22.04" = {
         ami             = "ami-0aeb7c931a5a61206"
-        subnet          = "subnet-0c2046d7a0595aa2c"
-        security_groups = ["sg-075f379cc5612e984"]
+        subnet          = "subnet-09b64de757828cdd4"
+        security_groups = ["sg-044ef7bc34691164a"]
         key_name        = "caos-dev-arm"
         instance_type   = "t3a.small"
         username        = "ubuntu"
@@ -108,8 +108,8 @@ variable "ec2_otels" {
       }
       "arm64:ubuntu22.04" = {
         ami             = "ami-0717cbd2f49a61ed0"
-        subnet          = "subnet-0c2046d7a0595aa2c"
-        security_groups = ["sg-075f379cc5612e984"]
+        subnet          = "subnet-09b64de757828cdd4"
+        security_groups = ["sg-044ef7bc34691164a"]
         key_name        = "caos-dev-arm"
         instance_type   = "t4g.small"
         username        = "ubuntu"
@@ -120,9 +120,9 @@ variable "ec2_otels" {
         }
       }
       "amd64:centos-stream" = {
-        ami             = "ami-0066ed1647780b41f"
-        subnet          = "subnet-0c2046d7a0595aa2c"
-        security_groups = ["sg-075f379cc5612e984"]
+        ami             = "ami-01529018e3919dace"
+        subnet          = "subnet-09b64de757828cdd4"
+        security_groups = ["sg-044ef7bc34691164a"]
         key_name        = "caos-dev-arm"
         instance_type   = "t3a.small"
         username        = "ec2-user"
@@ -133,9 +133,9 @@ variable "ec2_otels" {
         }
       }
       "arm64:centos-stream" = {
-        ami             = "ami-00c97145c04ff4c85"
-        subnet          = "subnet-0c2046d7a0595aa2c"
-        security_groups = ["sg-075f379cc5612e984"]
+        ami             = "ami-0e98f9d5c9841c9ad"
+        subnet          = "subnet-09b64de757828cdd4"
+        security_groups = ["sg-044ef7bc34691164a"]
         key_name        = "caos-dev-arm"
         instance_type   = "t4g.small"
         username        = "ec2-user"
@@ -147,8 +147,8 @@ variable "ec2_otels" {
       }
       "amd64:sles-12.5" = {
         ami             = "ami-0314425a95f19ff16"
-        subnet          = "subnet-0c2046d7a0595aa2c"
-        security_groups = ["sg-075f379cc5612e984"]
+        subnet          = "subnet-09b64de757828cdd4"
+        security_groups = ["sg-044ef7bc34691164a"]
         key_name        = "caos-dev-arm"
         instance_type   = "t3a.small"
         username        = "ec2-user"
@@ -160,8 +160,8 @@ variable "ec2_otels" {
       }
       "amd64:sles-15.2" = {
         ami             = "ami-0e44499c443e91acd"
-        subnet          = "subnet-0c2046d7a0595aa2c"
-        security_groups = ["sg-075f379cc5612e984"]
+        subnet          = "subnet-09b64de757828cdd4"
+        security_groups = ["sg-044ef7bc34691164a"]
         key_name        = "caos-dev-arm"
         instance_type   = "t3a.small"
         username        = "ec2-user"
@@ -172,9 +172,9 @@ variable "ec2_otels" {
         }
       }
       "amd64:sles-15.3" = {
-        ami             = "ami-0b7b425050b12e3f9"
-        subnet          = "subnet-0c2046d7a0595aa2c"
-        security_groups = ["sg-075f379cc5612e984"]
+        ami             = "ami-0446c700e1dc61753"
+        subnet          = "subnet-09b64de757828cdd4"
+        security_groups = ["sg-044ef7bc34691164a"]
         key_name        = "caos-dev-arm"
         instance_type   = "t3a.small"
         username        = "ec2-user"
@@ -186,8 +186,8 @@ variable "ec2_otels" {
       }
       "amd64:sles-15.4" = {
         ami             = "ami-0baf7d00b43fd908d"
-        subnet          = "subnet-0c2046d7a0595aa2c"
-        security_groups = ["sg-075f379cc5612e984"]
+        subnet          = "subnet-09b64de757828cdd4"
+        security_groups = ["sg-044ef7bc34691164a"]
         key_name        = "caos-dev-arm"
         instance_type   = "t3a.small"
         username        = "ec2-user"
@@ -198,9 +198,9 @@ variable "ec2_otels" {
         }
       }
       "arm64:sles-15.4" = {
-        ami             = "ami-0e7c79c3442262e35"
-        subnet          = "subnet-0c2046d7a0595aa2c"
-        security_groups = ["sg-075f379cc5612e984"]
+        ami             = "ami-052fd3067d337faf6"
+        subnet          = "subnet-09b64de757828cdd4"
+        security_groups = ["sg-044ef7bc34691164a"]
         key_name        = "caos-dev-arm"
         instance_type   = "t4g.small"
         username        = "ec2-user"
@@ -211,9 +211,9 @@ variable "ec2_otels" {
         }
       }
       "amd64:sles-15.5" = {
-        ami             = "ami-04504b468e262a288"
-        subnet          = "subnet-0c2046d7a0595aa2c"
-        security_groups = ["sg-075f379cc5612e984"]
+        ami             = "ami-0e03a27c1453107db"
+        subnet          = "subnet-09b64de757828cdd4"
+        security_groups = ["sg-044ef7bc34691164a"]
         key_name        = "caos-dev-arm"
         instance_type   = "t3a.small"
         username        = "ec2-user"
@@ -225,8 +225,8 @@ variable "ec2_otels" {
       }
       "amd64:sles-15.6" = {
         ami             = "ami-0a752653199c4fce6"
-        subnet          = "subnet-0c2046d7a0595aa2c"
-        security_groups = ["sg-075f379cc5612e984"]
+        subnet          = "subnet-09b64de757828cdd4"
+        security_groups = ["sg-044ef7bc34691164a"]
         key_name        = "caos-dev-arm"
         instance_type   = "t3a.small"
         username        = "ec2-user"
@@ -237,9 +237,9 @@ variable "ec2_otels" {
         }
       }
       "arm64:sles-15.5" = {
-        ami             = "ami-012bb28fd7e331024"
-        subnet          = "subnet-0c2046d7a0595aa2c"
-        security_groups = ["sg-075f379cc5612e984"]
+        ami             = "ami-046216af2ce255621"
+        subnet          = "subnet-09b64de757828cdd4"
+        security_groups = ["sg-044ef7bc34691164a"]
         key_name        = "caos-dev-arm"
         instance_type   = "t4g.small"
         username        = "ec2-user"
@@ -251,8 +251,8 @@ variable "ec2_otels" {
       }
       "arm64:sles-15.6" = {
         ami             = "ami-0bce4f43ac4014da1"
-        subnet          = "subnet-0c2046d7a0595aa2c"
-        security_groups = ["sg-075f379cc5612e984"]
+        subnet          = "subnet-09b64de757828cdd4"
+        security_groups = ["sg-044ef7bc34691164a"]
         key_name        = "caos-dev-arm"
         instance_type   = "t4g.small"
         username        = "ec2-user"
@@ -264,8 +264,8 @@ variable "ec2_otels" {
       }
       "amd64:redhat-8.4" = {
         ami             = "ami-0ba62214afa52bec7"
-        subnet          = "subnet-0c2046d7a0595aa2c"
-        security_groups = ["sg-075f379cc5612e984"]
+        subnet          = "subnet-09b64de757828cdd4"
+        security_groups = ["sg-044ef7bc34691164a"]
         key_name        = "caos-dev-arm"
         instance_type   = "t3a.small"
         username        = "ec2-user"
@@ -277,8 +277,8 @@ variable "ec2_otels" {
       }
       "amd64:redhat-9.0" = {
         ami             = "ami-078cbc4c2d057c244"
-        subnet          = "subnet-0c2046d7a0595aa2c"
-        security_groups = ["sg-075f379cc5612e984"]
+        subnet          = "subnet-09b64de757828cdd4"
+        security_groups = ["sg-044ef7bc34691164a"]
         key_name        = "caos-dev-arm"
         instance_type   = "t3a.small"
         username        = "ec2-user"
@@ -290,8 +290,8 @@ variable "ec2_otels" {
       }
       "arm64:redhat-9.0" = {
         ami             = "ami-01089181b0aa3be51"
-        subnet          = "subnet-0c2046d7a0595aa2c"
-        security_groups = ["sg-075f379cc5612e984"]
+        subnet          = "subnet-09b64de757828cdd4"
+        security_groups = ["sg-044ef7bc34691164a"]
         key_name        = "caos-dev-arm"
         instance_type   = "t4g.small"
         username        = "ec2-user"
@@ -303,8 +303,8 @@ variable "ec2_otels" {
       }
       "amd64:debian-bullseye" = {
         ami             = "ami-08a0dab67e025361b"
-        subnet          = "subnet-0c2046d7a0595aa2c"
-        security_groups = ["sg-075f379cc5612e984"]
+        subnet          = "subnet-09b64de757828cdd4"
+        security_groups = ["sg-044ef7bc34691164a"]
         key_name        = "caos-dev-arm"
         instance_type   = "t3a.small"
         username        = "admin"
@@ -316,8 +316,8 @@ variable "ec2_otels" {
       }
       "arm64:debian-bullseye" = {
         ami             = "ami-03cabbbc935f5826f"
-        subnet          = "subnet-0c2046d7a0595aa2c"
-        security_groups = ["sg-075f379cc5612e984"]
+        subnet          = "subnet-09b64de757828cdd4"
+        security_groups = ["sg-044ef7bc34691164a"]
         key_name        = "caos-dev-arm"
         instance_type   = "t4g.small"
         username        = "admin"
@@ -329,8 +329,8 @@ variable "ec2_otels" {
       }
       "amd64:debian-bookworm" = {
         ami             = "ami-02e9e442f629e6834"
-        subnet          = "subnet-0c2046d7a0595aa2c"
-        security_groups = ["sg-075f379cc5612e984"]
+        subnet          = "subnet-09b64de757828cdd4"
+        security_groups = ["sg-044ef7bc34691164a"]
         key_name        = "caos-dev-arm"
         instance_type   = "t3a.small"
         username        = "admin"
@@ -342,8 +342,8 @@ variable "ec2_otels" {
       }
       "arm64:debian-bookworm" = {
         ami             = "ami-05f312273b2ebaf0b"
-        subnet          = "subnet-0c2046d7a0595aa2c"
-        security_groups = ["sg-075f379cc5612e984"]
+        subnet          = "subnet-09b64de757828cdd4"
+        security_groups = ["sg-044ef7bc34691164a"]
         key_name        = "caos-dev-arm"
         instance_type   = "t4g.small"
         username        = "admin"
@@ -355,8 +355,8 @@ variable "ec2_otels" {
       }
       "amd64:al-2" = {
         ami             = "ami-077e31c4939f6a2f3"
-        subnet          = "subnet-0c2046d7a0595aa2c"
-        security_groups = ["sg-075f379cc5612e984"]
+        subnet          = "subnet-09b64de757828cdd4"
+        security_groups = ["sg-044ef7bc34691164a"]
         key_name        = "caos-dev-arm"
         instance_type   = "t3a.small"
         username        = "ec2-user"
@@ -368,8 +368,8 @@ variable "ec2_otels" {
       }
       "arm64:al-2" = {
         ami             = "ami-07a3e3eda401f8caa"
-        subnet          = "subnet-0c2046d7a0595aa2c"
-        security_groups = ["sg-075f379cc5612e984"]
+        subnet          = "subnet-09b64de757828cdd4"
+        security_groups = ["sg-044ef7bc34691164a"]
         key_name        = "caos-dev-arm"
         instance_type   = "t4g.small"
         username        = "ec2-user"
@@ -381,8 +381,8 @@ variable "ec2_otels" {
       }
       "amd64:al-2023" = {
         ami             = "ami-0103f211a154d64a6"
-        subnet          = "subnet-0c2046d7a0595aa2c"
-        security_groups = ["sg-075f379cc5612e984"]
+        subnet          = "subnet-09b64de757828cdd4"
+        security_groups = ["sg-044ef7bc34691164a"]
         key_name        = "caos-dev-arm"
         instance_type   = "t3a.small"
         username        = "ec2-user"
@@ -393,9 +393,9 @@ variable "ec2_otels" {
         }
       }
       "amd64:al-2023-fips" = {
-        ami             = "ami-0ec24135690b4ad82"
-        subnet          = "subnet-0c2046d7a0595aa2c"
-        security_groups = ["sg-075f379cc5612e984"]
+        ami             = "ami-085fa628e46dcb929"
+        subnet          = "subnet-09b64de757828cdd4"
+        security_groups = ["sg-044ef7bc34691164a"]
         key_name        = "caos-dev-arm"
         instance_type   = "t3a.small"
         username        = "ec2-user"
@@ -407,8 +407,8 @@ variable "ec2_otels" {
       }
       "arm64:al-2023" = {
         ami             = "ami-07d16074c2fdf3a19"
-        subnet          = "subnet-0c2046d7a0595aa2c"
-        security_groups = ["sg-075f379cc5612e984"]
+        subnet          = "subnet-09b64de757828cdd4"
+        security_groups = ["sg-044ef7bc34691164a"]
         key_name        = "caos-dev-arm"
         instance_type   = "t4g.small"
         username        = "ec2-user"
@@ -419,9 +419,9 @@ variable "ec2_otels" {
         }
       }
       "arm64:al-2023-fips" = {
-        ami             = "ami-0edddf62c25da5c5e"
-        subnet          = "subnet-0c2046d7a0595aa2c"
-        security_groups = ["sg-075f379cc5612e984"]
+        ami             = "ami-06014e12b8efb52e2"
+        subnet          = "subnet-09b64de757828cdd4"
+        security_groups = ["sg-044ef7bc34691164a"]
         key_name        = "caos-dev-arm"
         instance_type   = "t4g.small"
         username        = "ec2-user"
@@ -432,9 +432,9 @@ variable "ec2_otels" {
         }
       }
       "amd64:windows_2016" = {
-        ami             = "ami-0c465d57affbebd78"
-        subnet          = "subnet-0c2046d7a0595aa2c"
-        security_groups = ["sg-075f379cc5612e984"]
+        ami             = "ami-03d46abfa414238dd"
+        subnet          = "subnet-09b64de757828cdd4"
+        security_groups = ["sg-044ef7bc34691164a"]
         key_name        = "caos-dev-arm"
         instance_type   = "t3a.small"
         username        = "ansible"
@@ -445,9 +445,9 @@ variable "ec2_otels" {
         }
       }
       "amd64:windows_2019" = {
-        ami             = "ami-08b20395242518494"
-        subnet          = "subnet-0c2046d7a0595aa2c"
-        security_groups = ["sg-075f379cc5612e984"]
+        ami             = "ami-077e49a076b7e3847"
+        subnet          = "subnet-09b64de757828cdd4"
+        security_groups = ["sg-044ef7bc34691164a"]
         key_name        = "caos-dev-arm"
         instance_type   = "t3a.small"
         username        = "ansible"
@@ -458,22 +458,9 @@ variable "ec2_otels" {
         }
       }
       "amd64:windows_2022" = {
-        ami             = "ami-0feb3a0caad202bce"
-        subnet          = "subnet-0c2046d7a0595aa2c"
-        security_groups = ["sg-075f379cc5612e984"]
-        key_name        = "caos-dev-arm"
-        instance_type   = "t3a.small"
-        username        = "ansible"
-        platform        = "windows"
-        python          = ""
-        tags            = {
-          "otel_role" = "agent"
-        }
-      }
-      "amd64:windows_2025" = {
-        ami             = "ami-059a9049ae7e40d51"
-        subnet          = "subnet-0c2046d7a0595aa2c"
-        security_groups = ["sg-075f379cc5612e984"]
+        ami             = "ami-0780c2aa3485f2088"
+        subnet          = "subnet-09b64de757828cdd4"
+        security_groups = ["sg-044ef7bc34691164a"]
         key_name        = "caos-dev-arm"
         instance_type   = "t3a.small"
         username        = "ansible"


### PR DESCRIPTION
This reverts commit f31a62c1b1780ae80dda5a9ed5b808f097f7a4cf.

The workflows are failing on the new account this is purely for comparing workflows on the old account 